### PR TITLE
fix indentation of elm-srcs.nix

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -80,22 +80,20 @@ readDescription = do
 
 generateNixSource :: DerivationSource -> String
 generateNixSource ds =
-   -- TODO: pass name to fetchzip
-   [iTrim|
-   "${Package.toUrl (drvName ds)}" = fetchzip {
-     url = "${drvUrl ds}";
-     sha256 = "${drvHash ds}";
-     meta = {
-       version = "${drvVersion ds}";
-     };
-   };
-   |]
+  -- TODO: pass name to fetchzip
+  [i|  "${Package.toUrl (drvName ds)}" = fetchzip {
+    url = "${drvUrl ds}";
+    sha256 = "${drvHash ds}";
+    meta = {
+      version = "${drvVersion ds}";
+    };
+  };|]
 
 generateNixSources :: [DerivationSource] -> String
 generateNixSources dss =
   [iTrim|
-  { fetchzip  }: {
-    ${intercalate "\n" (map generateNixSource dss)}
+{ fetchzip }: {
+${intercalate "\n" (map generateNixSource dss)}
 }
   |]
 


### PR DESCRIPTION
This should fix the indentation of the generated `elm-srcs.nix` to be "correct".

I suppose some `iTrim` which outdents whole blocks could make this nicer?
