### PR TITLE
Don't pass the version field through fetchzip

### DIFF
--- a/data/default.nix
+++ b/data/default.nix
@@ -28,7 +28,7 @@ let
 
         \${lib.concatStrings (lib.mapAttrsToList (name: src: ''
           mkdir -p elm-stuff/packages/\${name}
-          ln -s \${src} elm-stuff/packages/\${name}/\${src.meta.version}
+          ln -s \${src.src} elm-stuff/packages/\${name}/\${src.version}
         '') sources)}
 
         runHook postSetupElmStuffPhase

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -81,12 +81,12 @@ readDescription = do
 generateNixSource :: DerivationSource -> String
 generateNixSource ds =
   -- TODO: pass name to fetchzip
-  [i|  "${Package.toUrl (drvName ds)}" = fetchzip {
-    url = "${drvUrl ds}";
-    sha256 = "${drvHash ds}";
-    meta = {
-      version = "${drvVersion ds}";
+  [i|  "${Package.toUrl (drvName ds)}" = {
+    src = fetchzip {
+      url = "${drvUrl ds}";
+      sha256 = "${drvHash ds}";
     };
+    version = "${drvVersion ds}";
   };|]
 
 generateNixSources :: [DerivationSource] -> String

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -80,22 +80,20 @@ readDescription = do
 
 generateNixSource :: DerivationSource -> String
 generateNixSource ds =
-   -- TODO: pass name to fetchzip
-   [iTrim|
-   "${Package.toUrl (drvName ds)}" = fetchzip {
-     url = "${drvUrl ds}";
-     sha256 = "${drvHash ds}";
-     meta = {
-       version = "${drvVersion ds}";
-     };
-   };
-   |]
+  -- TODO: pass name to fetchzip
+  [i|  "${Package.toUrl (drvName ds)}" = fetchzip {
+    url = "${drvUrl ds}";
+    sha256 = "${drvHash ds}";
+    meta = {
+      version = "${drvVersion ds}";
+    };
+  };|]
 
 generateNixSources :: [DerivationSource] -> String
 generateNixSources dss =
   [iTrim|
-  { fetchzip  }: {
-    ${intercalate "\n" (map generateNixSource dss)}
+{ fetchzip }: {
+${intercalate "\n" (map generateNixSource dss)}
 }
   |]
 


### PR DESCRIPTION
On top of #4.

Not at all sure this is the best way to do things, but:

The point here is that I've been using `elm2nix` to get a start at nix expressions that allow me to build elm apps against development versions of packages. It does all the important things right, all I need to do is replace some of the `fetchzip` calls in `elm-srcs.nix` by the appropriate `fetchgit` lines. Except I don't see how to get the `meta.version` field into the `fetchgit` result.

With this change, `fetchzip` and `fetchgit` can be used in much the same way. And it shouldn't break the default behaviour.
