### PR TITLE
configurable targets, exposed modules by default

### DIFF
--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p git stack -i bash
+#!nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/17.09.tar.gz -p git stack -i bash
 
 set -e
 

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -p git stack -i bash
 
+set -e -x
+
 stack install --nix
 
 MYTMPDIR=$(mktemp -d)
@@ -9,7 +11,9 @@ trap "rm -rf $MYTMPDIR" EXIT
 git clone https://github.com/debois/elm-mdl.git $MYTMPDIR/elm-mdl
 
 pushd $MYTMPDIR/elm-mdl
-  ~/.local/bin/elm2nix init > default.nix
+  ~/.local/bin/elm2nix init | sed -e '/^  targets/s/\\[\\]/["Material", "Material.Button"]/' > default.nix
   ~/.local/bin/elm2nix convert > elm-srcs.nix
   nix-build
+  test -e ./result/Material.js
+  test -e ./result/Material.Button.js
 popd

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-stack install --nix
+NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/17.09.tar.gz stack install --nix
 
 MYTMPDIR=$(mktemp -d)
 trap "rm -rf $MYTMPDIR" EXIT

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -p git stack -i bash
 
-set -e -x
+set -e
 
 stack install --nix
 
@@ -10,10 +10,17 @@ trap "rm -rf $MYTMPDIR" EXIT
 
 git clone https://github.com/debois/elm-mdl.git $MYTMPDIR/elm-mdl
 
+checkfile() {
+  if [ ! -e "$1" ]; then
+    echo "file missing: $1"
+    return 1
+  fi
+}
+
 pushd $MYTMPDIR/elm-mdl
-  ~/.local/bin/elm2nix init | sed -e '/^  targets/s/\\[\\]/["Material", "Material.Button"]/' > default.nix
+  ~/.local/bin/elm2nix init | sed -e '/^  targets/s/\[\]/["Material" "Material.Button"]/' > default.nix
   ~/.local/bin/elm2nix convert > elm-srcs.nix
   nix-build
-  test -e ./result/Material.js
-  test -e ./result/Material.Button.js
+  checkfile ./result/Material.js
+  checkfile ./result/Material.Button.js
 popd

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -52,6 +52,9 @@ generateDefault :: Manager.Manager ()
 generateDefault = do
   desc <- readDescription
   let name = toNixName (Desc.name desc) ++ "-" ++ show (Desc.version desc)
+  let srcdir = case Desc.sourceDirs desc of
+                    []    -> "."
+                    (a:_) -> a
   liftIO $ putStrLn [template|data/default.nix|]
 
 solveDependencies :: Manager.Manager ()


### PR DESCRIPTION
This is to allow building Javascript artifacts (what I thought was the original purpose of `elm2nix`).

Originally I was basing the list of targets on the list of exposed modules, but that doesn't really make much sense?

For my personal use, I need to be able to configure some (typically one) target. E.g. like I did here: https://github.com/robx/elm-pointer-draw/. (Or more involved with git dependencies: https://github.com/robx/elm-pointer-draw/tree/capture.)

Perhaps this could be achieved in a different way? Is this even what `elm2nix` is meant to help with?